### PR TITLE
FIX: do not setEditorContent if content undefined

### DIFF
--- a/addon/components/tinymce-ember.js
+++ b/addon/components/tinymce-ember.js
@@ -127,7 +127,7 @@ export default Component.extend({
       }
 
       if (this.content !== this.currentContent) {
-        this.setEditorContent(this.content);
+        this.setEditorContent(this.content || '');
       }
     }
   },


### PR DESCRIPTION
Error is raised if content is undefined