### PR TITLE
Replace String.prototype.replaceAll for compatibility

### DIFF
--- a/addon/components/editor.js
+++ b/addon/components/editor.js
@@ -85,7 +85,7 @@ export default Component.extend({
 
     // Generate and set editor's id for textarea
     const EditorId = `${this.editorName}-${guidFor(this)}`
-      .replaceAll(/[^a-z0-9]/gi, '-')
+      .replace(/[^a-z0-9]/gi, '-')
       .toLowerCase();
     this.setProperties({
       customEvents: this.customEvents ?? [],


### PR DESCRIPTION
We are getting some errors in our logging tool about `'string goes here'.replaceAll(_parameters_) is not a function`.
`String.prototype.replaceAll` is still not even a part of EcmaScript (cf: [https://github.com/tc39/proposal-string-replaceall](https://github.com/tc39/proposal-string-replaceall), stage 4, in the current draft, will be shipped in 2021), though it is already implemented in some browsers.

However, the way it is used/written can be replaced by `String.prototype.replace` without any issues (_replaceAll_ being useful to replace all occurrences when checking a string, where _replace_ works only on the first occurrence).