### PR TITLE
ci: bump NODE_VERSION from 16 to 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 3 * * *' # daily, at 3am
 
 env:
-  NODE_VERSION: '16'
+  NODE_VERSION: '20'
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Summary
- Bumps `NODE_VERSION` in `.github/workflows/main.yml` from `'16'` to `'20'`.
- Node 16 reached EOL in Sept 2023; the `Floating Dependencies` job (which runs `yarn install --no-lockfile`) started failing on master after `testem@3.20.0` was published, since it requires Node `^20.19.0 || ^22.12.0 || >=24.0.0`.
- The first master CI run to surface the breakage was the merge of #325 (`actions/setup-node@v3 → v6`), but that bump was not the cause — the previous master push was in January 2026, before testem's release.

## Failing run
[`runs/25502959091` on master](https://github.com/concordnow/tinymce-ember/actions/runs/25502959091) — both `Tests` and `Floating Dependencies` failed:
- `Floating Dependencies`: `error testem@3.20.0: The engine "node" is incompatible … Got "16.20.2"` — fixed by this PR.
- `Tests`: 1/10 flaky test (`Integration | Modifier | editor: editor content update should be propagated upstream on keypress`) unrelated to Node version. Will need a separate look.

## Test plan
- [ ] CI passes on this branch (especially `Floating Dependencies`)
- [ ] No engine warnings about Node 20 from other transitive deps
- [ ] Verify the flaky test on `Tests` is independent of this change (re-run if it pops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)